### PR TITLE
Windows native lib build directory

### DIFF
--- a/src/java/net/jpountz/util/Native.java
+++ b/src/java/net/jpountz/util/Native.java
@@ -26,7 +26,7 @@ public enum Native {
   ;
 
   private enum OS {
-    WINDOWS("windows", "dll"), LINUX("linux", "so"), MAC("mac", "dylib"), SOLARIS("solaris", "so");
+    WINDOWS("win32", "dll"), LINUX("linux", "so"), MAC("mac", "dylib"), SOLARIS("solaris", "so");
     public final String name, libExtension;
 
     private OS(String name, String libExtension) {


### PR DESCRIPTION
I have just tried to build this lib for Windows, but I had some problems. As specified in the Ant task, the directory to which the native lib is compiled is "win32", not "windows":

```
<condition property="platform" value="win32">
  <os family="windows"/>
</condition>
```

Moreover, I use the MinGW GNU compiler for Windows. I tried both 32 and 64-bit versions, and both compile to files with ".so" extension. I don't know if it is because cpptasks appends ".so" in windows systems or if it is MinGW's "fault". Either way, I also had to replace the second parameter in Native.java. I'm not pushing that modification because I don't know if other compilers (e.g. Visual C++) behave this way too.
