### PR TITLE
Made JNI sources ANSI C compatible.

### DIFF
--- a/src/jni/net_jpountz_lz4_LZ4JNI.c
+++ b/src/jni/net_jpountz_lz4_LZ4JNI.c
@@ -39,18 +39,22 @@ static void throw_OOM(JNIEnv *env) {
 JNIEXPORT jint JNICALL Java_net_jpountz_lz4_LZ4JNI_LZ4_1compress_1limitedOutput
   (JNIEnv *env, jclass cls, jbyteArray src, jint srcOff, jint srcLen, jbyteArray dest, jint destOff, jint maxDestLen) {
 
-  char* in = (char*) (*env)->GetPrimitiveArrayCritical(env, src, 0);
+  char* in;
+  char* out;
+  jint compressed;
+  
+  in = (char*) (*env)->GetPrimitiveArrayCritical(env, src, 0);
   if (in == NULL) {
     throw_OOM(env);
     return 0;
   }
-  char* out = (char*) (*env)->GetPrimitiveArrayCritical(env, dest, 0);
+  out = (char*) (*env)->GetPrimitiveArrayCritical(env, dest, 0);
   if (out == NULL) {
     throw_OOM(env);
     return 0;
   }
 
-  jint compressed = LZ4_compress_limitedOutput(in + srcOff, out + destOff, srcLen, maxDestLen);
+  compressed = LZ4_compress_limitedOutput(in + srcOff, out + destOff, srcLen, maxDestLen);
 
   (*env)->ReleasePrimitiveArrayCritical(env, src, in, 0);
   (*env)->ReleasePrimitiveArrayCritical(env, src, out, 0);
@@ -67,18 +71,22 @@ JNIEXPORT jint JNICALL Java_net_jpountz_lz4_LZ4JNI_LZ4_1compress_1limitedOutput
 JNIEXPORT jint JNICALL Java_net_jpountz_lz4_LZ4JNI_LZ4_1compressHC
   (JNIEnv *env, jclass cls, jbyteArray src, jint srcOff, jint srcLen, jbyteArray dest, jint destOff, jint maxDestLen) {
 
-  char* in = (char*) (*env)->GetPrimitiveArrayCritical(env, src, 0);
+  char* in;
+  char* out;
+  jint compressed;
+  
+  in = (char*) (*env)->GetPrimitiveArrayCritical(env, src, 0);
   if (in == NULL) {
     throw_OOM(env);
     return 0;
   } 
-  char* out = (char*) (*env)->GetPrimitiveArrayCritical(env, dest, 0);
+  out = (char*) (*env)->GetPrimitiveArrayCritical(env, dest, 0);
   if (out == NULL) {
     throw_OOM(env);
     return 0;
   }
 
-  jint compressed = LZ4_compressHC_limitedOutput(in + srcOff, out + destOff, srcLen, maxDestLen);
+  compressed = LZ4_compressHC_limitedOutput(in + srcOff, out + destOff, srcLen, maxDestLen);
 
   (*env)->ReleasePrimitiveArrayCritical(env, src, in, 0);
   (*env)->ReleasePrimitiveArrayCritical(env, src, out, 0);
@@ -95,18 +103,22 @@ JNIEXPORT jint JNICALL Java_net_jpountz_lz4_LZ4JNI_LZ4_1compressHC
 JNIEXPORT jint JNICALL Java_net_jpountz_lz4_LZ4JNI_LZ4_1decompress_1fast
   (JNIEnv *env, jclass cls, jbyteArray src, jint srcOff, jbyteArray dest, jint destOff, jint destLen) {
 
-  char* in = (char*) (*env)->GetPrimitiveArrayCritical(env, src, 0);
+  char* in;
+  char* out;
+  jint compressed;
+  
+  in = (char*) (*env)->GetPrimitiveArrayCritical(env, src, 0);
   if (in == NULL) {
     throw_OOM(env);
     return 0;
   }
-  char* out = (char*) (*env)->GetPrimitiveArrayCritical(env, dest, 0);
+  out = (char*) (*env)->GetPrimitiveArrayCritical(env, dest, 0);
   if (out == NULL) {
     throw_OOM(env);
     return 0;
   }
 
-  jint compressed = LZ4_decompress_fast(in + srcOff, out + destOff, destLen);
+  compressed = LZ4_decompress_fast(in + srcOff, out + destOff, destLen);
 
   (*env)->ReleasePrimitiveArrayCritical(env, src, in, 0);
   (*env)->ReleasePrimitiveArrayCritical(env, src, out, 0);
@@ -123,18 +135,22 @@ JNIEXPORT jint JNICALL Java_net_jpountz_lz4_LZ4JNI_LZ4_1decompress_1fast
 JNIEXPORT jint JNICALL Java_net_jpountz_lz4_LZ4JNI_LZ4_1decompress_1safe
   (JNIEnv *env, jclass cls, jbyteArray src, jint srcOff, jint srcLen, jbyteArray dest, jint destOff, jint maxDestLen) {
 
-  char* in = (char*) (*env)->GetPrimitiveArrayCritical(env, src, 0);
+  char* in;
+  char* out;
+  jint decompressed;
+
+  in = (char*) (*env)->GetPrimitiveArrayCritical(env, src, 0);
   if (in == NULL) {
     throw_OOM(env);
     return 0;
   }
-  char* out = (char*) (*env)->GetPrimitiveArrayCritical(env, dest, 0);
+  out = (char*) (*env)->GetPrimitiveArrayCritical(env, dest, 0);
   if (out == NULL) {
     throw_OOM(env);
     return 0;
   }
 
-  jint decompressed = LZ4_decompress_safe(in + srcOff, out + destOff, srcLen, maxDestLen);
+  decompressed = LZ4_decompress_safe(in + srcOff, out + destOff, srcLen, maxDestLen);
 
   (*env)->ReleasePrimitiveArrayCritical(env, src, in, 0);
   (*env)->ReleasePrimitiveArrayCritical(env, src, out, 0);
@@ -151,18 +167,22 @@ JNIEXPORT jint JNICALL Java_net_jpountz_lz4_LZ4JNI_LZ4_1decompress_1safe
 JNIEXPORT jint JNICALL Java_net_jpountz_lz4_LZ4JNI_LZ4_1decompress_1fast_1withPrefix64k
   (JNIEnv *env, jclass cls, jbyteArray src, jint srcOff, jbyteArray dest, jint destOff, jint destLen) {
 
-  char* in = (char*) (*env)->GetPrimitiveArrayCritical(env, src, 0);
+  char* in;
+  char* out;
+  jint compressed;
+
+  in = (char*) (*env)->GetPrimitiveArrayCritical(env, src, 0);
   if (in == NULL) {
     throw_OOM(env);
     return 0;
   }
-  char* out = (char*) (*env)->GetPrimitiveArrayCritical(env, dest, 0);
+  out = (char*) (*env)->GetPrimitiveArrayCritical(env, dest, 0);
   if (out == NULL) {
     throw_OOM(env);
     return 0;
   }
 
-  jint compressed = LZ4_decompress_fast_withPrefix64k(in + srcOff, out + destOff, destLen);
+  compressed = LZ4_decompress_fast_withPrefix64k(in + srcOff, out + destOff, destLen);
 
   (*env)->ReleasePrimitiveArrayCritical(env, src, in, 0);
   (*env)->ReleasePrimitiveArrayCritical(env, src, out, 0);
@@ -179,18 +199,22 @@ JNIEXPORT jint JNICALL Java_net_jpountz_lz4_LZ4JNI_LZ4_1decompress_1fast_1withPr
 JNIEXPORT jint JNICALL Java_net_jpountz_lz4_LZ4JNI_LZ4_1decompress_1safe_1withPrefix64k
   (JNIEnv *env, jclass cls, jbyteArray src, jint srcOff, jint srcLen, jbyteArray dest, jint destOff, jint maxDestLen) {
 
-  char* in = (char*) (*env)->GetPrimitiveArrayCritical(env, src, 0);
+  char* in;
+  char* out;
+  jint decompressed;
+
+  in = (char*) (*env)->GetPrimitiveArrayCritical(env, src, 0);
   if (in == NULL) {
     throw_OOM(env);
     return 0;
   }
-  char* out = (char*) (*env)->GetPrimitiveArrayCritical(env, dest, 0);
+  out = (char*) (*env)->GetPrimitiveArrayCritical(env, dest, 0);
   if (out == NULL) {
     throw_OOM(env);
     return 0;
   }
 
-  jint decompressed = LZ4_decompress_safe_withPrefix64k(in + srcOff, out + destOff, srcLen, maxDestLen);
+  decompressed = LZ4_decompress_safe_withPrefix64k(in + srcOff, out + destOff, srcLen, maxDestLen);
 
   (*env)->ReleasePrimitiveArrayCritical(env, src, in, 0);
   (*env)->ReleasePrimitiveArrayCritical(env, src, out, 0);

--- a/src/jni/net_jpountz_xxhash_XXHashJNI.c
+++ b/src/jni/net_jpountz_xxhash_XXHashJNI.c
@@ -40,13 +40,16 @@ static void throw_OOM(JNIEnv *env) {
 JNIEXPORT jint JNICALL Java_net_jpountz_xxhash_XXHashJNI_XXH32
   (JNIEnv *env, jclass cls, jbyteArray buf, jint off, jint len, jint seed) {
 
-  char* in = (char*) (*env)->GetPrimitiveArrayCritical(env, buf, 0);
+  char* in;
+  jint h32;
+
+  in = (char*) (*env)->GetPrimitiveArrayCritical(env, buf, 0);
   if (in == NULL) {
     throw_OOM(env);
     return 0;
   }
 
-  jint h32 = XXH32(in + off, len, seed);
+  h32 = XXH32(in + off, len, seed);
 
   (*env)->ReleasePrimitiveArrayCritical(env, buf, in, 0);
 


### PR DESCRIPTION
MS Visual C compilers (2010) do not support C99 so the JNI wrapper
functions must be ANSI C. This means variables must be declared at the
beginning of functions.
