### PR TITLE
Using Java unsafe implementation crashes JVM on Solaris sparcv9 with 64 bit JVM

### DIFF
--- a/src/java/net/jpountz/lz4/LZ4Factory.java
+++ b/src/java/net/jpountz/lz4/LZ4Factory.java
@@ -18,6 +18,7 @@ import java.lang.reflect.Field;
 import java.util.Arrays;
 
 import net.jpountz.util.Native;
+import net.jpountz.util.Utils;
 
 /**
  * Entry point for the LZ4 API.
@@ -105,9 +106,13 @@ public final class LZ4Factory {
    * working {@link sun.misc.Unsafe}.
    */
   public static LZ4Factory fastestJavaInstance() {
-    try {
-      return unsafeInstance();
-    } catch (Throwable t) {
+    if (Utils.isUnalignedAccessAllowed()) {
+      try {
+        return unsafeInstance();
+      } catch (Throwable t) {
+        return safeInstance();
+      }
+    } else {
       return safeInstance();
     }
   }

--- a/src/java/net/jpountz/util/Native.java
+++ b/src/java/net/jpountz/util/Native.java
@@ -46,7 +46,7 @@ public enum Native {
       return OS.MAC;
     } else if (osName.contains("Windows")) {
       return OS.WINDOWS;
-    } else if (osName.contains("Solaris")) {
+    } else if (osName.contains("Solaris") || osName.contains("SunOS")) {
       return OS.SOLARIS;
     } else {
       throw new UnsupportedOperationException("Unsupported operating system: "

--- a/src/java/net/jpountz/util/Utils.java
+++ b/src/java/net/jpountz/util/Utils.java
@@ -21,6 +21,17 @@ public enum Utils {
 
   public static final ByteOrder NATIVE_BYTE_ORDER = ByteOrder.nativeOrder();
 
+  private static final boolean unalignedAccessAllowed;
+  static {
+    String arch = System.getProperty("os.arch");
+    unalignedAccessAllowed = arch.equals("i386") || arch.equals("x86")
+            || arch.equals("amd64") || arch.equals("x86_64");
+  }
+
+  public static boolean isUnalignedAccessAllowed() {
+    return unalignedAccessAllowed;
+  }
+
   public static void checkRange(byte[] buf, int off) {
     if (off < 0 || off >= buf.length) {
       throw new ArrayIndexOutOfBoundsException(off);

--- a/src/java/net/jpountz/xxhash/XXHashFactory.java
+++ b/src/java/net/jpountz/xxhash/XXHashFactory.java
@@ -18,6 +18,7 @@ import java.lang.reflect.Field;
 import java.util.Random;
 
 import net.jpountz.util.Native;
+import net.jpountz.util.Utils;
 
 /**
  * Entry point to get {@link XXHash32} and {@link StreamingXXHash32} instances.
@@ -103,9 +104,13 @@ public final class XXHashFactory {
    * working {@link sun.misc.Unsafe}.
    */
   public static XXHashFactory fastestJavaInstance() {
-    try {
-      return unsafeInstance();
-    } catch (Throwable t) {
+    if (Utils.isUnalignedAccessAllowed()) {
+      try {
+        return unsafeInstance();
+      } catch (Throwable t) {
+        return safeInstance();
+      }
+    } else {
       return safeInstance();
     }
   }


### PR DESCRIPTION
Hi,
    Using lz4 under solaris sparcv9 with 64bit jvm is not possible at the moment. If I use LZ4Factory.fastestInstance() and factory.fastCompressor() it tries to use Unsafe and once it does so, JVM crashes with problematic frame [libjvm.so+0xc5212c]  Unsafe_GetInt+0x158. I looked at the java DirectByteBuffer and saw that Java checks for architecrure before using Unsafe and if it is not one of the known, it reads ints and longs by bytes.
    This commit changes UnsafeUtils to check os.arch and if it is not one of the known, it reads ins and long byte by byte.
    Running under 32 bit java on solaris passes all tests. Running under 64 bit java passes all tests except those that use native library, for some reason native library doesn't work for me. It crashes at some point. Maybe I just dont know how to compile it.
