### PR TITLE
fix integer overflow in literals decompression, port of the fix in r118

### DIFF
--- a/src/lz4/lz4.h
+++ b/src/lz4/lz4.h
@@ -74,9 +74,9 @@ LZ4_decompress_safe() :
 //****************************
 // Advanced Functions
 //****************************
-
-static inline int LZ4_compressBound(int isize)   { return ((isize) + ((isize)/255) + 16); }
-#define           LZ4_COMPRESSBOUND(    isize)            ((isize) + ((isize)/255) + 16)
+#define LZ4_MAX_INPUT_SIZE        0x7E000000   /* 2 113 929 216 bytes */
+static inline int LZ4_compressBound(int isize) { return ((unsigned int)(isize) > (unsigned int)LZ4_MAX_INPUT_SIZE ? 0 : (isize) + ((isize)/255) + 16); }
+#define           LZ4_COMPRESSBOUND(isize)              ((unsigned int)(isize) > (unsigned int)LZ4_MAX_INPUT_SIZE ? 0 : (isize) + ((isize)/255) + 16)
 
 /*
 LZ4_compressBound() :


### PR DESCRIPTION
Port of a minimal fix for integer overflow in literals decompression that could cause buffer overrun.

Please review it.

Thanks,
