### PR TITLE
Add basic LZ4 Frame v1.5.0 support

### DIFF
--- a/src/java/net/jpountz/lz4/LZ4FrameInputStream.java
+++ b/src/java/net/jpountz/lz4/LZ4FrameInputStream.java
@@ -1,0 +1,331 @@
+package net.jpountz.lz4;
+
+import net.jpountz.xxhash.XXHash32;
+import net.jpountz.xxhash.XXHashFactory;
+
+import java.io.FilterInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+
+/**
+ * A partial implementation of the v1.5.0 LZ4 Frame format. This class is NOT thread safe
+ * Not Supported:
+ * * Dependent blocks
+ * * Legacy streams
+ *
+ * @see <a href="https://docs.google.com/document/d/1cl8N1bmkTdIpPLtnlzbBSFAdUeyNo5fwfHbHU7VRNWY">LZ4 Framing
+ *      Format Spec 1.5.0</a>
+ *      
+ * Originally based on kafka's KafkaLZ4BlockInputStream
+ */
+public class LZ4FrameInputStream extends FilterInputStream
+{
+
+  public static final String PREMATURE_EOS = "Stream ended prematurely";
+  public static final String NOT_SUPPORTED = "Stream unsupported";
+  public static final String BLOCK_HASH_MISMATCH = "Block checksum mismatch";
+  public static final String DESCRIPTOR_HASH_MISMATCH = "Stream frame descriptor corrupted";
+  public static final int MAGIC_SKIPPABLE_BASE = 0x184D2A50;
+
+  private final LZ4SafeDecompressor decompressor;
+  private final XXHash32 checksum;
+  private final byte[] headerArray = new byte[LZ4FrameOutputStream.LZ4_MAX_HEADER_LENGTH];
+  private final ByteBuffer headerBuffer = ByteBuffer.wrap(headerArray).order(ByteOrder.LITTLE_ENDIAN);
+  private byte[] compressedBuffer;
+  private ByteBuffer buffer = null;
+  private byte[] rawBuffer = null;
+  private int maxBlockSize = -1;
+  private long expectedContentSize = -1L;
+  private long totalContentSize = 0L;
+
+  private LZ4FrameOutputStream.FrameInfo frameInfo = null;
+
+  /**
+   * Create a new {@link InputStream} that will decompress data using the LZ4 algorithm.
+   *
+   * @param in The stream to decompress
+   * @throws IOException
+   */
+  public LZ4FrameInputStream(InputStream in) throws IOException {
+    this(in, LZ4Factory.fastestInstance().safeDecompressor(), XXHashFactory.fastestInstance().hash32());
+  }
+
+  public LZ4FrameInputStream(InputStream in, LZ4SafeDecompressor decompressor,  XXHash32 checksum) throws IOException
+  {
+    super(in);
+    this.decompressor = decompressor;
+    this.checksum = checksum;
+    nextFrameInfo();
+  }
+
+
+
+  /**
+   * Try and load in the next valid frame info. This will skip over skippable frames.
+   * @return True if a frame was loaded. False if there are no more frames in the stream.
+   * @throws IOException On input stream read exception
+   */
+  private boolean nextFrameInfo() throws IOException
+  {
+    int size = 0;
+    do {
+      final int mySize = in.read(readNumberBuff.array(), size, LZ4FrameOutputStream.INTEGER_BYTES - size);
+      if(mySize < 0){
+        return false;
+      }
+      size += mySize;
+    }while(size < LZ4FrameOutputStream.INTEGER_BYTES);
+    final int magic = readNumberBuff.getInt(0);
+    if(magic == LZ4FrameOutputStream.MAGIC){
+      readHeader();
+      return true;
+    } else if ((magic >>> 8) == (MAGIC_SKIPPABLE_BASE>>>8)){
+      skippableFrame();
+      return nextFrameInfo();
+    } else {
+      throw new IOException(NOT_SUPPORTED);
+    }
+  }
+
+  private void skippableFrame() throws IOException
+  {
+    int skipSize = readInt(in);
+    final byte[] skipBuffer = new byte[1<<10];
+    while(skipSize > 0){
+      final int mySize = in.read(skipBuffer, 0, Math.min(skipSize, skipBuffer.length));
+      if(mySize < 0){
+        throw new IOException(PREMATURE_EOS);
+      }
+      skipSize -= mySize;
+    }
+  }
+
+  /**
+   * Reads the frame descriptor from the underlying {@link InputStream}.
+   *
+   * @throws IOException
+   */
+  private void readHeader() throws IOException {
+    headerBuffer.rewind();
+
+    final int flgRead = in.read();
+    if(flgRead < 0){
+      throw new IOException(PREMATURE_EOS);
+    }
+    final int bdRead = in.read();
+    if(bdRead < 0){
+      throw new IOException(PREMATURE_EOS);
+    }
+
+    final byte flgByte = (byte)(flgRead & 0xFF);
+    final LZ4FrameOutputStream.FLG flg = LZ4FrameOutputStream.FLG.fromByte(flgByte);
+    headerBuffer.put(flgByte);
+    final byte bdByte = (byte)(bdRead & 0xFF);
+    final LZ4FrameOutputStream.BD bd = LZ4FrameOutputStream.BD.fromByte(bdByte);
+    headerBuffer.put(bdByte);
+
+    this.frameInfo = new LZ4FrameOutputStream.FrameInfo(flg, bd);
+
+    if(flg.isEnabled(LZ4FrameOutputStream.FLG.Bits.CONTENT_SIZE)){
+      expectedContentSize = readLong(in);
+      headerBuffer.putLong(expectedContentSize);
+    }
+
+    // check stream descriptor hash
+    final byte hash = (byte) ((checksum.hash(headerArray, 0, headerBuffer.position(), 0) >> 8) & 0xFF);
+    final int expectedHash = in.read();
+    if(expectedHash < 0){
+      throw new IOException(PREMATURE_EOS);
+    }
+
+    if (hash != (byte)(expectedHash & 0xFF)) {
+      throw new IOException(DESCRIPTOR_HASH_MISMATCH);
+    }
+
+    maxBlockSize = frameInfo.getBD().getBlockMaximumSize();
+    compressedBuffer = new byte[maxBlockSize]; // Reused during different compressions
+    rawBuffer = new byte[maxBlockSize];
+    buffer = ByteBuffer.wrap(rawBuffer);
+    buffer.limit(0);
+  }
+
+  private final ByteBuffer readNumberBuff = ByteBuffer.allocate(LZ4FrameOutputStream.LONG_BYTES).order(ByteOrder.LITTLE_ENDIAN);
+
+  private long readLong(InputStream stream) throws IOException
+  {
+    int offset = 0;
+    do{
+      final int mySize = stream.read(readNumberBuff.array(), offset, LZ4FrameOutputStream.LONG_BYTES - offset);
+      if(mySize < 0){
+        throw new IOException(PREMATURE_EOS);
+      }
+      offset += mySize;
+    }while(offset < LZ4FrameOutputStream.LONG_BYTES);
+    return readNumberBuff.getInt(0);
+  }
+  private int readInt(InputStream stream) throws IOException
+  {
+    int offset = 0;
+    do{
+      final int mySize = stream.read(readNumberBuff.array(), offset, LZ4FrameOutputStream.INTEGER_BYTES - offset);
+      if(mySize < 0){
+        throw new IOException(PREMATURE_EOS);
+      }
+      offset += mySize;
+    }while(offset < LZ4FrameOutputStream.INTEGER_BYTES);
+    return readNumberBuff.getInt(0);
+  }
+  /**
+   * Decompress (if necessary) buffered data, optionally computes and validates a XXHash32 checksum, and writes the
+   * result to a buffer.
+   *
+   * @throws IOException
+   */
+  private void readBlock() throws IOException {
+    int blockSize = readInt(in);
+
+    // Check for EndMark
+    if (blockSize == 0) {
+      if(frameInfo.isEnabled(LZ4FrameOutputStream.FLG.Bits.CONTENT_CHECKSUM)){
+        final int contentChecksum = readInt(in);
+        if(contentChecksum != frameInfo.currentStreamHash()){
+          throw new IOException("Content checksum mismatch");
+        }
+      }
+      frameInfo.finish();
+      return;
+    }
+
+    final boolean compressed = (blockSize & LZ4FrameOutputStream.LZ4_FRAME_INCOMPRESSIBLE_MASK) == 0;
+    final byte[] tmpBuffer; // Use a temporary buffer, potentially one used for compression
+    if (compressed) {
+      tmpBuffer = compressedBuffer;
+    }else {
+      tmpBuffer = rawBuffer;
+      blockSize ^= LZ4FrameOutputStream.LZ4_FRAME_INCOMPRESSIBLE_MASK;
+    }
+    if (blockSize > maxBlockSize) {
+      throw new IOException(String.format("Block size %s exceeded max: %s", blockSize, maxBlockSize));
+    }
+
+    int offset = 0;
+    while(offset < blockSize){
+      final int lastRead = in.read(tmpBuffer, offset, blockSize - offset);
+      if(lastRead < 0){
+        throw new IOException(PREMATURE_EOS);
+      }
+      offset += lastRead;
+    }
+
+    // verify block checksum
+    if (frameInfo.isEnabled(LZ4FrameOutputStream.FLG.Bits.BLOCK_CHECKSUM)){
+      final int hashCheck = readInt(in);
+      if(hashCheck != checksum.hash(tmpBuffer, 0, blockSize, 0)){
+        throw new IOException(BLOCK_HASH_MISMATCH);
+      }
+    }
+
+
+    final int currentBufferSize;
+    if (compressed) {
+      try {
+        currentBufferSize = decompressor.decompress(tmpBuffer, 0, blockSize, rawBuffer, 0, rawBuffer.length);
+      } catch (LZ4Exception e) {
+        throw new IOException(e);
+      }
+    } else {
+      currentBufferSize = blockSize;
+    }
+    if(frameInfo.isEnabled(LZ4FrameOutputStream.FLG.Bits.CONTENT_CHECKSUM)) {
+      frameInfo.updateStreamHash(rawBuffer, 0, currentBufferSize);
+    }
+    totalContentSize += currentBufferSize;
+    buffer.limit(currentBufferSize);
+    buffer.rewind();
+  }
+
+  @Override
+  public int read() throws IOException {
+    if (frameInfo.isFinished()) {
+      if(!nextFrameInfo()) {
+        return -1;
+      }
+    }
+    if (buffer.remaining() == 0) {
+      readBlock();
+    }
+    if (frameInfo.isFinished()) {
+      return read();
+    }
+
+    return buffer.get();
+  }
+
+  @Override
+  public int read(byte[] b, int off, int len) throws IOException {
+    if((off < 0) || (off >= b.length) || (off+len > b.length)){
+      throw new IndexOutOfBoundsException();
+    }
+    if (frameInfo.isFinished()) {
+      if(!nextFrameInfo()) {
+        return -1;
+      }
+    }
+    if (buffer.remaining() == 0) {
+      readBlock();
+    }
+    if (frameInfo.isFinished()) {
+      return read(b, off, len);
+    }
+    len = Math.min(len, buffer.remaining());
+    buffer.get(b, off, len);
+    return len;
+  }
+
+  @Override
+  public long skip(long n) throws IOException {
+    if (frameInfo.isFinished()) {
+      return 0;
+    }
+    if (available() == 0) {
+      readBlock();
+    }
+    if (frameInfo.isFinished()) {
+      return 0;
+    }
+    n = Math.min(n, buffer.remaining());
+    buffer.position(buffer.position() + (int)n);
+    return n;
+  }
+
+  @Override
+  public int available() throws IOException {
+    return buffer.remaining();
+  }
+
+  @Override
+  public void close() throws IOException {
+    super.close();
+    if(frameInfo.isEnabled(LZ4FrameOutputStream.FLG.Bits.CONTENT_SIZE) && expectedContentSize != totalContentSize){
+      throw new IOException("Size check mismatch");
+    }
+  }
+
+  @Override
+  public synchronized void mark(int readlimit) {
+    throw new UnsupportedOperationException("mark not supported");
+  }
+
+  @Override
+  public synchronized void reset() throws IOException {
+    throw new UnsupportedOperationException("reset not supported");
+  }
+
+  @Override
+  public boolean markSupported() {
+    return false;
+  }
+
+}

--- a/src/java/net/jpountz/lz4/LZ4FrameOutputStream.java
+++ b/src/java/net/jpountz/lz4/LZ4FrameOutputStream.java
@@ -1,0 +1,406 @@
+package net.jpountz.lz4;
+
+import net.jpountz.util.Utils;
+import net.jpountz.xxhash.StreamingXXHash32;
+import net.jpountz.xxhash.XXHash32;
+import net.jpountz.xxhash.XXHashFactory;
+
+import java.io.FilterOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.Arrays;
+import java.util.BitSet;
+
+/**
+ * A partial implementation of the v1.5.0 LZ4 Frame format. This class is NOT thread safe
+ * Not Supported:
+ * * Dependent blocks
+ * * Legacy streams
+ * * Multiple frames (one KafkaLZ4BlockOutputStream is one frame)
+ *
+ * @see <a href="https://docs.google.com/document/d/1cl8N1bmkTdIpPLtnlzbBSFAdUeyNo5fwfHbHU7VRNWY">LZ4 Framing
+ *      Format Spec 1.5.0</a>
+ * 
+ * Originally based on kafka's KafkaLZ4BlockOutputStream
+ */
+public class LZ4FrameOutputStream extends FilterOutputStream
+{
+
+  protected static final int INTEGER_BYTES = Integer.SIZE >>> 3; // or Integer.BYTES in Java 1.8
+  protected static final int LONG_BYTES = Long.SIZE >>> 3; // or Long.BYTES in Java 1.8
+
+  public static final int MAGIC = 0x184D2204;
+  public static final int LZ4_MAX_HEADER_LENGTH =
+      4 + // magic
+      1 + // FLG
+      1 + // BD
+      8 + // Content Size
+      1; // HC
+  public static final int LZ4_FRAME_INCOMPRESSIBLE_MASK = 0x80000000;
+  public static final FLG.Bits[] DEFAULT_FEATURES = new FLG.Bits[]{FLG.Bits.BLOCK_INDEPENDENCE};
+
+  public static final String CLOSED_STREAM = "The stream is already closed";
+
+  public static enum BLOCKSIZE{
+    SIZE_64KB(4), SIZE_256KB(5), SIZE_1MB(6), SIZE_4MB(7);
+    private final int indicator;
+    BLOCKSIZE(int indicator){
+      this.indicator = indicator;
+    }
+    public int getIndicator(){
+      return this.indicator;
+    }
+    public static BLOCKSIZE valueOf(int indicator){
+      switch(indicator){
+        case 7: return SIZE_4MB;
+        case 6: return SIZE_1MB;
+        case 5: return SIZE_256KB;
+        case 4: return SIZE_64KB;
+        default: throw new IllegalArgumentException(String.format("Block size must be 4-7. Cannot use value of [%d]", indicator));
+      }
+    }
+  }
+
+  private final LZ4Compressor compressor;
+  private final XXHash32 checksum;
+  private final ByteBuffer buffer; // Buffer for uncompressed input data
+  private final byte[] compressedBuffer; // Only allocated once so it can be reused
+  private final int maxBlockSize;
+  private final long knownSize;
+  private final ByteBuffer intLEBuffer = ByteBuffer.allocate(INTEGER_BYTES).order(ByteOrder.LITTLE_ENDIAN);
+
+  private FrameInfo frameInfo = null;
+
+
+  /**
+   * Create a new {@link OutputStream} that will compress data using the LZ4 algorithm.
+   *
+   * @param out The output stream to compress
+   * @param blockSize The BLOCKSIZE to use.
+   * @param bits A set of features to use
+   * @throws IOException
+   */
+  public LZ4FrameOutputStream(OutputStream out, BLOCKSIZE blockSize, FLG.Bits... bits) throws IOException {
+    this(out, blockSize, -1L, bits);
+  }
+
+  /**
+   * Create a new {@link OutputStream} that will compress data using the LZ4 algorithm.
+   *
+   * @param out The output stream to compress
+   * @param blockSize The BLOCKSIZE to use.
+   * @param bits A set of features to use
+   * @param knownSize The size of the uncompressed data. A value less than zero means unknown.
+   * @throws IOException
+   */
+  public LZ4FrameOutputStream(OutputStream out, BLOCKSIZE blockSize, long knownSize, FLG.Bits... bits) throws IOException {
+    super(out);
+    compressor = LZ4Factory.fastestInstance().fastCompressor();
+    checksum = XXHashFactory.fastestInstance().hash32();
+    frameInfo = new FrameInfo(new FLG(FLG.DEFAULT_VERSION, bits), new BD(blockSize));
+    maxBlockSize = frameInfo.getBD().getBlockMaximumSize();
+    buffer = ByteBuffer.allocate(maxBlockSize).order(ByteOrder.LITTLE_ENDIAN);
+    compressedBuffer = new byte[compressor.maxCompressedLength(maxBlockSize)];
+    if(frameInfo.getFLG().isEnabled(FLG.Bits.CONTENT_SIZE) && knownSize < 0){
+      throw new IllegalArgumentException("Known size must be greater than zero in order to use the known size feature");
+    }
+    this.knownSize = knownSize;
+    writeHeader();
+  }
+
+  /**
+   * Create a new {@link OutputStream} that will compress data using the LZ4 algorithm.
+   *
+   * @param out The stream to compress
+   * @param blockSize Default: 4. The block size used during compression. 4=64kb, 5=256kb, 6=1mb, 7=4mb. All other
+   *            values will generate an exception
+   * @throws IOException
+   */
+  public LZ4FrameOutputStream(OutputStream out, BLOCKSIZE blockSize) throws IOException {
+    this(out, blockSize, DEFAULT_FEATURES);
+  }
+
+  /**
+   * Create a new {@link OutputStream} that will compress data using the LZ4 algorithm.
+   *
+   * @param out The output stream to compress
+   * @throws IOException
+   */
+  public LZ4FrameOutputStream(OutputStream out) throws IOException {
+    this(out, BLOCKSIZE.SIZE_4MB);
+  }
+
+  /**
+   * Writes the magic number and frame descriptor to the underlying {@link OutputStream}.
+   *
+   * @throws IOException
+   */
+  private void writeHeader() throws IOException {
+    final ByteBuffer headerBuffer = ByteBuffer.allocate(LZ4_MAX_HEADER_LENGTH).order(ByteOrder.LITTLE_ENDIAN);
+    headerBuffer.putInt(MAGIC);
+    headerBuffer.put(frameInfo.getFLG().toByte());
+    headerBuffer.put(frameInfo.getBD().toByte());
+    if(frameInfo.isEnabled(FLG.Bits.CONTENT_SIZE)) {
+      headerBuffer.putLong(knownSize);
+    }
+    // compute checksum on all descriptor fields
+    final int hash = (checksum.hash(headerBuffer.array(), INTEGER_BYTES, headerBuffer.position() - INTEGER_BYTES, 0) >> 8) & 0xFF;
+    headerBuffer.put((byte) hash);
+    // write out frame descriptor
+    out.write(headerBuffer.array(), 0, headerBuffer.position());
+  }
+
+  /**
+   * Compresses buffered data, optionally computes an XXHash32 checksum, and writes the result to the underlying
+   * {@link OutputStream}.
+   *
+   * @throws IOException
+   */
+  private void writeBlock() throws IOException {
+    if (buffer.position() == 0) {
+      return;
+    }
+    // Make sure there's no stale data
+    Arrays.fill(compressedBuffer, (byte) 0);
+
+    int compressedLength = compressor.compress(buffer.array(), 0, buffer.position(), compressedBuffer, 0);
+    final byte[] bufferToWrite;
+    final int compressMethod;
+
+    // Store block uncompressed if compressed length is greater (incompressible)
+    if (compressedLength >= buffer.position()) {
+      compressedLength = buffer.position();
+      bufferToWrite = Arrays.copyOf(buffer.array(), compressedLength);
+      compressMethod = LZ4_FRAME_INCOMPRESSIBLE_MASK;
+    } else {
+      bufferToWrite = compressedBuffer;
+      compressMethod = 0;
+    }
+
+    // Write content
+    intLEBuffer.putInt(0, compressedLength | compressMethod);
+    out.write(intLEBuffer.array());
+    out.write(bufferToWrite, 0, compressedLength);
+
+    // Calculate and write block checksum
+    if (frameInfo.isEnabled(FLG.Bits.BLOCK_CHECKSUM)) {
+      intLEBuffer.putInt(0, checksum.hash(bufferToWrite, 0, compressedLength, 0));
+      out.write(intLEBuffer.array());
+    }
+    buffer.rewind();
+  }
+
+  /**
+   * Similar to the {@link #writeBlock()} method. Writes a 0-length block (without block checksum) to signal the end
+   * of the block stream.
+   *
+   * @throws IOException
+   */
+  private void writeEndMark() throws IOException {
+    intLEBuffer.putInt(0, 0);
+    out.write(intLEBuffer.array());
+    if(frameInfo.isEnabled(FLG.Bits.CONTENT_CHECKSUM)){
+      intLEBuffer.putInt(0, frameInfo.currentStreamHash());
+      out.write(intLEBuffer.array());
+    }
+    frameInfo.finish();
+  }
+
+  @Override
+  public void write(int b) throws IOException {
+    ensureNotFinished();
+    if (buffer.position() == maxBlockSize) {
+      writeBlock();
+    }
+    buffer.put((byte) b);
+
+    if(frameInfo.isEnabled(FLG.Bits.CONTENT_CHECKSUM)) {
+      frameInfo.updateStreamHash(new byte[]{(byte) b}, 0, 1);
+    }
+  }
+
+  @Override
+  public void write(byte[] b, int off, int len) throws IOException {
+    if((off < 0) || (off >= b.length) || (off+len > b.length)){
+      throw new IndexOutOfBoundsException();
+    }
+    ensureNotFinished();
+
+    // while b will fill the buffer
+    while (len > buffer.remaining()) {
+      int sizeWritten = buffer.remaining();
+      // fill remaining space in buffer
+      buffer.put(b, off, sizeWritten);
+      if(frameInfo.isEnabled(FLG.Bits.CONTENT_CHECKSUM)) {
+        frameInfo.updateStreamHash(b, off, sizeWritten);
+      }
+      writeBlock();
+      // compute new offset and length
+      off += sizeWritten;
+      len -= sizeWritten;
+    }
+    buffer.put(b, off, len);
+
+    if(frameInfo.isEnabled(FLG.Bits.CONTENT_CHECKSUM)) {
+      frameInfo.updateStreamHash(b, off, len);
+    }
+  }
+
+  @Override
+  public void flush() throws IOException {
+    if (!frameInfo.isFinished()) {
+      writeBlock();
+    }
+    super.flush();
+  }
+
+  /**
+   * A simple state check to ensure the stream is still open.
+   */
+  private void ensureNotFinished() {
+    if (frameInfo.isFinished()) {
+      throw new IllegalStateException(CLOSED_STREAM);
+    }
+  }
+
+  @Override
+  public void close() throws IOException {
+    if (!frameInfo.isFinished()) {
+      writeEndMark();
+      flush();
+      frameInfo.finish();
+    }
+    super.close();
+  }
+
+  public static class FLG {
+    private static final int DEFAULT_VERSION = 1;
+
+    private final BitSet bitSet;
+    private final int version;
+
+    public enum Bits{
+      RESERVED_0(0),
+      RESERVED_1(1),
+      CONTENT_CHECKSUM(2),
+      CONTENT_SIZE(3),
+      BLOCK_CHECKSUM(4),
+      BLOCK_INDEPENDENCE(5);
+
+      private final int position;
+      Bits(int position){
+        this.position = position;
+      }
+    }
+    public FLG(int version, Bits... bits){
+      this.bitSet = new BitSet(8);
+      this.version = version;
+      if(bits != null){
+        for(Bits bit : bits){
+          bitSet.set(bit.position);
+        }
+      }
+      validate();
+    }
+    private FLG(int version, byte b){
+      this.bitSet = BitSet.valueOf(new byte[]{b});
+      this.version = version;
+      validate();
+    }
+
+    public static FLG fromByte(byte flg) {
+      final byte versionMask = (byte)(flg & (3<<6));
+      return new FLG(versionMask >>> 6, (byte) (flg ^ versionMask));
+    }
+
+    public byte toByte() {
+      return (byte)(bitSet.toByteArray()[0] | ((version & 3) << 6));
+    }
+
+    private void validate() {
+      if (bitSet.get(Bits.RESERVED_0.position)) {
+        throw new RuntimeException("Reserved0 field must be 0");
+      }
+      if (bitSet.get(Bits.RESERVED_1.position)) {
+        throw new RuntimeException("Reserved1 field must be 0");
+      }
+      if (!bitSet.get(Bits.BLOCK_INDEPENDENCE.position)) {
+        throw new RuntimeException("Dependent block stream is unsupported");
+      }
+      if (version != DEFAULT_VERSION) {
+        throw new RuntimeException(String.format("Version %d is unsupported", version));
+      }
+    }
+
+    public boolean isEnabled(Bits bit){
+      return bitSet.get(bit.position);
+    }
+
+    public int getVersion() {
+      return version;
+    }
+  }
+
+  public static class BD {
+    private static final int RESERVED_MASK = 0x8F;
+
+    private final BLOCKSIZE blockSizeValue;
+
+    private BD(BLOCKSIZE blockSizeValue) {
+      this.blockSizeValue = blockSizeValue;
+    }
+
+    public static BD fromByte(byte bd) {
+      int blockMaximumSize = (bd >>> 4) & 7;
+      if((bd & RESERVED_MASK) > 0){
+        throw new RuntimeException("Reserved fields must be 0");
+      }
+
+      return new BD(BLOCKSIZE.valueOf(blockMaximumSize));
+    }
+
+    // 2^(2n+8)
+    public int getBlockMaximumSize() {
+      return 1 << ((2 * blockSizeValue.getIndicator()) + 8);
+    }
+
+    public byte toByte() {
+      return (byte) ((blockSizeValue.getIndicator() & 7) << 4);
+    }
+  }
+
+  public static class FrameInfo{
+    private final FLG flg;
+    private final BD bd;
+    private final StreamingXXHash32 streamHash;
+    private boolean finished = false;
+    public FrameInfo(FLG flg, BD bd){
+      this.flg = flg;
+      this.bd = bd;
+      this.streamHash = flg.isEnabled(FLG.Bits.CONTENT_CHECKSUM) ? XXHashFactory.fastestInstance().newStreamingHash32(0) : null;
+    }
+    public boolean isEnabled(FLG.Bits bit){
+      return flg.isEnabled(bit);
+    }
+    public FLG getFLG(){
+      return this.flg;
+    }
+    public BD getBD(){
+      return this.bd;
+    }
+    public void updateStreamHash(byte[] buff, int off, int len){
+      this.streamHash.update(buff, off, len);
+    }
+    public int currentStreamHash(){
+      return this.streamHash.getValue();
+    }
+    public void finish(){
+      this.finished = true;
+    }
+    public boolean isFinished(){
+      return this.finished;
+    }
+  }
+}

--- a/src/test/net/jpountz/lz4/LZ4FrameIOStreamTest.java
+++ b/src/test/net/jpountz/lz4/LZ4FrameIOStreamTest.java
@@ -1,0 +1,376 @@
+package net.jpountz.lz4;
+
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Assume;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.io.EOFException;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.IntBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.BitSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Random;
+
+/**
+ *
+ */
+@RunWith(Parameterized.class)
+public class LZ4FrameIOStreamTest
+{
+  private static void copy(InputStream in, OutputStream out) throws IOException
+  {
+    final byte[] buffer = new byte[1<<10];
+    int inSize = in.read(buffer);;
+    while(inSize>=0) {
+      out.write(buffer, 0, inSize);
+      inSize = in.read(buffer);
+    }
+    out.flush();
+  }
+  @Parameterized.Parameters
+  public static Iterable<Object[]> parameters(){
+    final List<Object[]> retval = new LinkedList<>(
+        Arrays.asList(
+            new Object[]{0},
+            new Object[]{1},
+            new Object[]{1 << 10},
+            new Object[]{(1 << 10) + 1},
+            new Object[]{1 << 16},
+            new Object[]{1 << 17},
+            new Object[]{1 << 20}
+        ));
+    final Random rnd = new Random(78370789134L); // Chosen by lightly  smashing my keyboard a few times.
+    for(int i = 0; i < 10; ++i){
+      retval.add(new Object[]{Math.abs(rnd.nextInt()) % (1<<22)});
+    }
+    return retval;
+  }
+  private final int testSize;
+  public LZ4FrameIOStreamTest(int testSize){
+    this.testSize = testSize;
+  }
+  File tmpFile = null;
+
+  @Before
+  public void setUp() throws IOException
+  {
+    final int fill = 0xDEADBEEF;
+    tmpFile = Files.createTempFile("lz4ioTest", ".dat").toFile();
+    final Random rnd = new Random(5378L);
+    int sizeRemaining = testSize;
+    try (OutputStream os = Files.newOutputStream(tmpFile.toPath())) {
+      while (sizeRemaining > 0) {
+        final byte[] buff = new byte[Math.min(sizeRemaining, 1 << 10)];
+        final IntBuffer intBuffer = ByteBuffer.wrap(buff).order(ByteOrder.LITTLE_ENDIAN).asIntBuffer();
+        rnd.nextBytes(buff);
+        while(intBuffer.hasRemaining()){
+          intBuffer.put(fill);
+        }
+        os.write(buff);
+        sizeRemaining -= buff.length;
+      }
+    }
+    Assert.assertEquals(testSize, tmpFile.length());
+  }
+
+  @After
+  public void tearDown(){
+    if(tmpFile != null && tmpFile.exists() && !tmpFile.delete()){
+      Assert.fail(String.format("Could not delete file [%s]", tmpFile.getAbsolutePath()));
+    }
+  }
+
+  private void fillBuffer(final byte[] buffer, final InputStream is) throws IOException
+  {
+    int offset = 0;
+    while(offset < buffer.length){
+      final int myLength = is.read(buffer, offset, buffer.length - offset);
+      if(myLength < 0){
+        throw new EOFException("End of stream");
+      }
+      offset += myLength;
+    }
+  }
+
+  private void validateStreamEquals(InputStream is, File file) throws IOException
+  {
+    int size = (int) file.length();
+    try(InputStream fis = new FileInputStream(file)) {
+      while (size > 0) {
+        final byte[] buffer0 = new byte[Math.min(size, 1 << 10)];
+        final byte[] buffer1 = new byte[Math.min(size, 1 << 10)];
+        fillBuffer(buffer1, fis);
+        fillBuffer(buffer0, is);
+        for(int i = 0; i < buffer0.length; ++i){
+          Assert.assertEquals(buffer0[i], buffer1[i]);
+        }
+        size -= buffer0.length;
+      }
+    }
+  }
+
+  @Test
+  public void testValidator() throws IOException
+  {
+    try (InputStream is = new FileInputStream(tmpFile)) {
+      validateStreamEquals(is, tmpFile);
+    }
+    final File file = Files.createTempFile("copyTmp", ".dat").toFile();
+    try{
+      try(InputStream is = new FileInputStream(tmpFile)){
+        try(OutputStream os = new FileOutputStream(file)){
+          copy(is, os);
+        }
+      }
+      try(InputStream is = new FileInputStream(file)){
+        validateStreamEquals(is, file);
+      }
+    }finally{
+      file.delete();
+    }
+  }
+
+  @Test
+  public void testOutputSimple() throws IOException
+  {
+    final File lz4File = Files.createTempFile("lz4test", ".lz4").toFile();
+    try {
+      try (OutputStream os = new LZ4FrameOutputStream(new FileOutputStream(lz4File))) {
+        try (InputStream is = new FileInputStream(tmpFile)) {
+          copy(is, os);
+        }
+      }
+      final FileChannel channel = FileChannel.open(lz4File.toPath());
+      final ByteBuffer buffer = ByteBuffer.allocate(1024).order(ByteOrder.LITTLE_ENDIAN);
+      channel.read(buffer);
+      buffer.rewind();
+      Assert.assertEquals(LZ4FrameOutputStream.MAGIC, buffer.getInt());
+      final BitSet b = BitSet.valueOf(new byte[]{buffer.get()});
+      Assert.assertFalse(b.get(0));
+      Assert.assertFalse(b.get(1));
+      Assert.assertFalse(b.get(2));
+      Assert.assertFalse(b.get(3));
+      Assert.assertFalse(b.get(4));
+      Assert.assertTrue(b.get(5));
+      LZ4FrameOutputStream.BD bd = LZ4FrameOutputStream.BD.fromByte(buffer.get());
+      Assert.assertEquals(LZ4FrameOutputStream.BLOCKSIZE.SIZE_4MB.getIndicator() << 4, bd.toByte());
+    }
+    finally {
+      lz4File.delete();
+    }
+  }
+
+  @Test
+  public void testInputOutputSimple() throws IOException
+  {
+    final File lz4File = Files.createTempFile("lz4test", ".lz4").toFile();
+    try {
+      try (OutputStream os = new LZ4FrameOutputStream(new FileOutputStream(lz4File))) {
+        try (InputStream is = new FileInputStream(tmpFile)) {
+          copy(is, os);
+        }
+      }
+      try(InputStream is = new LZ4FrameInputStream(new FileInputStream(lz4File))){
+        validateStreamEquals(is, tmpFile);
+      }
+    }
+    finally {
+      lz4File.delete();
+    }
+  }
+
+
+  @Test
+  public void testInputOutputSkipped() throws IOException
+  {
+    final File lz4File = Files.createTempFile("lz4test", ".lz4").toFile();
+    try {
+      try(FileOutputStream fos = new FileOutputStream(lz4File)) {
+        final int skipSize = 1<<10;
+        final ByteBuffer skipBuffer = ByteBuffer.allocate(skipSize + 8).order(ByteOrder.LITTLE_ENDIAN);
+        skipBuffer.putInt(LZ4FrameInputStream.MAGIC_SKIPPABLE_BASE | 0x00000007); // anything 00 through FF should work
+        skipBuffer.putInt(skipSize);
+        final byte[] skipRandom = new byte[skipSize];
+        new Random(478278L).nextBytes(skipRandom);
+        skipBuffer.put(skipRandom);
+        fos.write(skipBuffer.array());
+        try (OutputStream os = new LZ4FrameOutputStream(fos)) {
+          try (InputStream is = new FileInputStream(tmpFile)) {
+            copy(is, os);
+          }
+        }
+      }
+      try(InputStream is = new LZ4FrameInputStream(new FileInputStream(lz4File))){
+        validateStreamEquals(is, tmpFile);
+      }
+    }
+    finally {
+      lz4File.delete();
+    }
+  }
+
+
+  @Test
+  public void testStreamWithContentSize() throws IOException
+  {
+    final File lz4File = Files.createTempFile("lz4test", ".lz4").toFile();
+    try {
+      try (OutputStream os = new LZ4FrameOutputStream(new FileOutputStream(lz4File),
+                                                      LZ4FrameOutputStream.BLOCKSIZE.SIZE_4MB,
+                                                      tmpFile.length(),
+                                                      LZ4FrameOutputStream.FLG.Bits.BLOCK_INDEPENDENCE,
+                                                      LZ4FrameOutputStream.FLG.Bits.CONTENT_CHECKSUM,
+                                                      LZ4FrameOutputStream.FLG.Bits.CONTENT_SIZE)) {
+        try (InputStream is = new FileInputStream(tmpFile)) {
+          copy(is, os);
+        }
+      }
+      try(InputStream is = new LZ4FrameInputStream(new FileInputStream(lz4File))){
+        validateStreamEquals(is, tmpFile);
+      }
+    }
+    finally {
+      lz4File.delete();
+    }
+  }
+
+
+  @Test
+  public void testInputOutputMultipleFiles() throws IOException
+  {
+    final File lz4File = Files.createTempFile("lz4test", ".lz4").toFile();
+    try {
+      try (OutputStream os = new LZ4FrameOutputStream(new FileOutputStream(lz4File))) {
+        try (InputStream is = new FileInputStream(tmpFile)) {
+          copy(is, os);
+        }
+      }
+      final long oneLength = lz4File.length();
+      try(OutputStream os = new FileOutputStream(lz4File, true)){
+        for(int i = 0; i < 3; ++i) {
+          try(InputStream is = new FileInputStream(lz4File)) {
+            long size = oneLength;
+            while(size > 0) {
+              final byte[] buff = new byte[Math.min((int) size, 1 << 10)];
+              fillBuffer(buff, is);
+              os.write(buff);
+              size -= buff.length;
+            }
+          }
+        }
+      }
+      try(InputStream is = new LZ4FrameInputStream(new FileInputStream(lz4File))){
+        validateStreamEquals(is, tmpFile);
+        validateStreamEquals(is, tmpFile);
+        validateStreamEquals(is, tmpFile);
+        validateStreamEquals(is, tmpFile);
+      }
+    }
+    finally {
+      lz4File.delete();
+    }
+  }
+
+  @Test
+  public void testNativeCompressIfAvailable() throws IOException, InterruptedException
+  {
+    Assume.assumeTrue(hasNativeLz4CLI());
+    nativeCompress();
+    nativeCompress("--no-frame-crc");
+  }
+
+  private void nativeCompress(String... args) throws IOException, InterruptedException
+  {
+    final File lz4File = Files.createTempFile("lz4test", ".lz4").toFile();
+    lz4File.delete();
+    try {
+      final ProcessBuilder builder = new ProcessBuilder();
+      final ArrayList<String> cmd = new ArrayList<>();
+      cmd.add("lz4");
+      if(args != null) {
+        cmd.addAll(Arrays.asList(args));
+      }
+      cmd.add(tmpFile.getAbsolutePath());
+      cmd.add(lz4File.getAbsolutePath());
+      builder.command(cmd.toArray(new String[cmd.size()]));
+      builder.inheritIO();
+      Process process = builder.start();
+      int retval = process.waitFor();
+      Assert.assertEquals(0, retval);
+      try (OutputStream os = new LZ4FrameOutputStream(new FileOutputStream(lz4File))) {
+        try (InputStream is = new FileInputStream(tmpFile)) {
+          copy(is, os);
+        }
+      }
+      try(InputStream is = new LZ4FrameInputStream(new FileInputStream(lz4File))){
+        validateStreamEquals(is, tmpFile);
+      }
+    }
+    finally {
+      lz4File.delete();
+    }
+  }
+
+
+  private static boolean hasNativeLz4CLI() throws IOException, InterruptedException
+  {
+    ProcessBuilder checkBuilder = new ProcessBuilder().command("lz4", "-V").inheritIO();
+    Process checkProcess = checkBuilder.start();
+    return checkProcess.waitFor() == 0;
+  }
+  @Test
+  public void testNativeDecompresIfAvailable() throws IOException, InterruptedException
+  {
+    Assume.assumeTrue(hasNativeLz4CLI());
+    final File lz4File = Files.createTempFile("lz4test", ".lz4").toFile();
+    final File unCompressedFile = Files.createTempFile("lz4raw", ".dat").toFile();
+    unCompressedFile.delete();
+    lz4File.delete();
+    try {
+      try (OutputStream os = new LZ4FrameOutputStream(new FileOutputStream(lz4File),
+                                                      LZ4FrameOutputStream.BLOCKSIZE.SIZE_4MB,
+                                                      tmpFile.length(),
+                                                      LZ4FrameOutputStream.FLG.Bits.BLOCK_INDEPENDENCE,
+                                                      LZ4FrameOutputStream.FLG.Bits.CONTENT_SIZE,
+                                                      LZ4FrameOutputStream.FLG.Bits.CONTENT_CHECKSUM)) {
+        try (InputStream is = new FileInputStream(tmpFile)) {
+          copy(is, os);
+        }
+      }
+      try (InputStream is = new LZ4FrameInputStream(new FileInputStream(lz4File))) {
+        validateStreamEquals(is, tmpFile);
+      }
+
+      final ProcessBuilder builder = new ProcessBuilder();
+      builder.command("lz4", "-d", "-vvvvvvv", lz4File.getAbsolutePath(), unCompressedFile.getAbsolutePath()).inheritIO();
+      Process process = builder.start();
+      int retval = process.waitFor();
+      Assert.assertEquals(0, retval);
+      try (InputStream is = new FileInputStream(unCompressedFile)) {
+        validateStreamEquals(is, tmpFile);
+      }
+    }
+    finally {
+      lz4File.delete();
+      unCompressedFile.delete();
+    }
+  }
+}


### PR DESCRIPTION
This PR is to add support for most of the features of Frames 1.5.0 as found at https://docs.google.com/document/d/1cl8N1bmkTdIpPLtnlzbBSFAdUeyNo5fwfHbHU7VRNWY

This is a port of some [Kafka code](https://raw.githubusercontent.com/apache/kafka/trunk/clients/src/main/java/org/apache/kafka/common/record/ByteBufferOutputStream.java)

This is technically ASF Apache license 2.0 code.
