### PR TITLE
read concated stream

### DIFF
--- a/src/java/net/jpountz/lz4/LZ4BlockInputStream.java
+++ b/src/java/net/jpountz/lz4/LZ4BlockInputStream.java
@@ -49,6 +49,7 @@ public final class LZ4BlockInputStream extends FilterInputStream {
   private int originalLen;
   private int o;
   private boolean finished;
+  private boolean stopOnEmptyBlock;
 
   /**
    * Create a new {@link InputStream}.
@@ -68,6 +69,11 @@ public final class LZ4BlockInputStream extends FilterInputStream {
     this.compressedBuffer = new byte[HEADER_LENGTH];
     o = originalLen = 0;
     finished = false;
+    stopOnEmptyBlock = true;
+  }
+
+  void setStopOnEmptyBlock(boolean stop) {
+    stopOnEmptyBlock = stop;
   }
 
   /**
@@ -183,7 +189,11 @@ public final class LZ4BlockInputStream extends FilterInputStream {
       if (check != 0) {
         throw new IOException("Stream is corrupted");
       }
-      refill();
+      if (!stopOnEmptyBlock) {
+        refill();
+      } else {
+        finished = true;
+      }
       return;
     }
     if (buffer.length < originalLen) {

--- a/src/java/net/jpountz/lz4/LZ4BlockInputStream.java
+++ b/src/java/net/jpountz/lz4/LZ4BlockInputStream.java
@@ -90,6 +90,9 @@ public final class LZ4BlockInputStream extends FilterInputStream {
 
   @Override
   public int available() throws IOException {
+    if (o == originalLen) {
+      refill();
+    }
     return originalLen - o;
   }
 
@@ -147,7 +150,12 @@ public final class LZ4BlockInputStream extends FilterInputStream {
   }
 
   private void refill() throws IOException {
-    readFully(compressedBuffer, HEADER_LENGTH);
+    try {
+      readFully(compressedBuffer, HEADER_LENGTH);
+    } catch (EOFException e) {
+      finished = true;
+      return;
+    }
     for (int i = 0; i < MAGIC_LENGTH; ++i) {
       if (compressedBuffer[i] != MAGIC[i]) {
         throw new IOException("Stream is corrupted");
@@ -175,7 +183,7 @@ public final class LZ4BlockInputStream extends FilterInputStream {
       if (check != 0) {
         throw new IOException("Stream is corrupted");
       }
-      finished = true;
+      refill();
       return;
     }
     if (buffer.length < originalLen) {


### PR DESCRIPTION
In Apache Spark, we have a fast path to merge two compressed shuffle files together by concat the bytes directly (without decompress and compress again), this rely on that the decompressor  to handle concated streams.

The BlockStream uses an empty block as the end of a stream, this PR change to skip the empty block until the end of stream. (also added a flag for this behavior change, having old behavior by default).
