### PR TITLE
Try to load lz4-java from java.library.path, then fallback to bundled

### DIFF
--- a/src/java/net/jpountz/util/Native.java
+++ b/src/java/net/jpountz/util/Native.java
@@ -71,6 +71,16 @@ public enum Native {
     if (loaded) {
       return;
     }
+
+    // Try to load lz4-java (liblz4-java.so on Linux) from the java.library.path.
+    try {
+      System.loadLibrary("lz4-java");
+      loaded = true;
+      return;
+    } catch (UnsatisfiedLinkError ex) {
+      // Doesn't exist, so proceed to loading bundled library.
+    }
+
     String resourceName = resourceName();
     InputStream is = Native.class.getResourceAsStream(resourceName);
     if (is == null) {


### PR DESCRIPTION
Use system-provided lz4-java, if it's available on the `java.library.path` (the default location where Java looks for native libraries), and fallback to bundled binary if it's not. This allows user to use lz4 java even
on systems that are not directly supported, like Linux with musl libc, uClibc etc.
