### PR TITLE
Read concatenated byte stream in LZ4BlockInputStream

### DIFF
--- a/src/java/net/jpountz/lz4/LZ4BlockInputStream.java
+++ b/src/java/net/jpountz/lz4/LZ4BlockInputStream.java
@@ -61,7 +61,7 @@ public final class LZ4BlockInputStream extends FilterInputStream {
    *                          write the stream
    * @param stopOnEmptyBlock  whether read is stopped on an empty block
    */
-  public LZ4BlockInputStream(InputStream in, LZ4FastDecompressor decompressor, Checksum checksum, Boolean stopOnEmptyBlock) {
+  public LZ4BlockInputStream(InputStream in, LZ4FastDecompressor decompressor, Checksum checksum, boolean stopOnEmptyBlock) {
     super(in);
     this.decompressor = decompressor;
     this.checksum = checksum;
@@ -83,7 +83,7 @@ public final class LZ4BlockInputStream extends FilterInputStream {
 
   /**
    * Create a new instance using {@link XXHash32} for checksuming.
-   * @see #LZ4BlockInputStream(InputStream, LZ4FastDecompressor, Checksum, Boolean)
+   * @see #LZ4BlockInputStream(InputStream, LZ4FastDecompressor, Checksum, boolean)
    * @see StreamingXXHash32#asChecksum()
    */
   public LZ4BlockInputStream(InputStream in, LZ4FastDecompressor decompressor) {
@@ -92,10 +92,10 @@ public final class LZ4BlockInputStream extends FilterInputStream {
 
   /**
    * Create a new instance using {@link XXHash32} for checksuming.
-   * @see #LZ4BlockInputStream(InputStream, LZ4FastDecompressor, Checksum, Boolean)
+   * @see #LZ4BlockInputStream(InputStream, LZ4FastDecompressor, Checksum, boolean)
    * @see StreamingXXHash32#asChecksum()
    */
-  public LZ4BlockInputStream(InputStream in, Boolean stopOnEmptyBlock) {
+  public LZ4BlockInputStream(InputStream in, boolean stopOnEmptyBlock) {
     this(in, LZ4Factory.fastestInstance().fastDecompressor(), XXHashFactory.fastestInstance().newStreamingHash32(DEFAULT_SEED).asChecksum(), stopOnEmptyBlock);
   }
 

--- a/src/test/net/jpountz/lz4/LZ4BlockStreamingTest.java
+++ b/src/test/net/jpountz/lz4/LZ4BlockStreamingTest.java
@@ -306,14 +306,6 @@ public class LZ4BlockStreamingTest extends AbstractLZ4Test {
     return total;
   }
 
-  static class LZ4BlockInputStreamSupportStreamConcatenation extends LZ4BlockInputStream {
-
-    public LZ4BlockInputStreamSupportStreamConcatenation(InputStream in) {
-      super(in);
-      setStopOnEmptyBlock(false);
-    }
-  }
-
   @Test
   public void testConcatenationOfSerializedStreams() throws IOException {
     final byte[] testBytes1 = randomArray(64, 256);
@@ -346,8 +338,7 @@ public class LZ4BlockStreamingTest extends AbstractLZ4Test {
     in1.close();
 
     // Check if we can read concatenated byte stream
-    LZ4BlockInputStream in2 = new LZ4BlockInputStreamSupportStreamConcatenation(
-            new ByteArrayInputStream(concatenatedBytes));
+    LZ4BlockInputStream in2 = new LZ4BlockInputStream(new ByteArrayInputStream(concatenatedBytes), false);
     byte[] actual2 = new byte[128];
     assertEquals(128, readFully(in2, actual2));
     assertEquals(-1, in2.read());


### PR DESCRIPTION
This pr fixed issues when reading concatenated byte stream in `LZ4BlockInputStream`.
This comes from #76.