### PR TITLE
Fix LZ4{Block|Frame}InputStream.skip in some corner cases

### DIFF
--- a/src/java/net/jpountz/lz4/LZ4BlockInputStream.java
+++ b/src/java/net/jpountz/lz4/LZ4BlockInputStream.java
@@ -172,14 +172,14 @@ public class LZ4BlockInputStream extends FilterInputStream {
 
   @Override
   public long skip(long n) throws IOException {
-    if (finished) {
-      return -1;
+    if (n <= 0 || finished) {
+      return 0;
     }
     if (o == originalLen) {
       refill();
     }
     if (finished) {
-      return -1;
+      return 0;
     }
     final int skipped = (int) Math.min(n, originalLen - o);
     o += skipped;

--- a/src/java/net/jpountz/lz4/LZ4FrameInputStream.java
+++ b/src/java/net/jpountz/lz4/LZ4FrameInputStream.java
@@ -307,6 +307,9 @@ public class LZ4FrameInputStream extends FilterInputStream {
 
   @Override
   public long skip(long n) throws IOException {
+    if (n <= 0) {
+      return 0;
+    }
     while (buffer.remaining() == 0) {
       if (frameInfo.isFinished()) {
 	if (!nextFrameInfo()) {


### PR DESCRIPTION
According to `InputStream.skip` javadoc, `LZ4{Block|Frame}InputStream.skip` should return 0 when `n <= 0` or EOF.