### PR TITLE
Expose native LZ4_compress_fast_continue API in LZ4JNI

### DIFF
--- a/src/java/net/jpountz/lz4/LZ4JNI.java
+++ b/src/java/net/jpountz/lz4/LZ4JNI.java
@@ -34,6 +34,7 @@ enum LZ4JNI {
 
   static native void init();
   static native int LZ4_compress_limitedOutput(byte[] srcArray, ByteBuffer srcBuffer, int srcOff, int srcLen, byte[] destArray, ByteBuffer destBuffer, int destOff, int maxDestLen);
+  static native int LZ4_compress_fast_continue(byte[] srcArray, ByteBuffer srcBuffer, int srcOff, int srcLen, byte[] destArray, ByteBuffer destBuffer, int destOff, int maxDestLen, int acceleration);
   static native int LZ4_compressHC(byte[] srcArray, ByteBuffer srcBuffer, int srcOff, int srcLen, byte[] destArray, ByteBuffer destBuffer, int destOff, int maxDestLen, int compressionLevel);
   static native int LZ4_decompress_fast(byte[] srcArray, ByteBuffer srcBuffer, int srcOff, byte[] destArray, ByteBuffer destBuffer, int destOff, int destLen);
   static native int LZ4_decompress_safe(byte[] srcArray, ByteBuffer srcBuffer, int srcOff, int srcLen, byte[] destArray, ByteBuffer destBuffer, int destOff, int maxDestLen);

--- a/src/jni/net_jpountz_lz4_LZ4JNI.c
+++ b/src/jni/net_jpountz_lz4_LZ4JNI.c
@@ -87,6 +87,54 @@ JNIEXPORT jint JNICALL Java_net_jpountz_lz4_LZ4JNI_LZ4_1compress_1limitedOutput
 
 /*
  * Class:     net_jpountz_lz4_LZ4JNI
+ * Method:    LZ4_compress_fast_contine
+ * Signature: ([BLjava/nio/ByteBuffer;II[BLjava/nio/ByteBuffer;III)I
+ */
+JNIEXPORT jint JNICALL Java_net_jpountz_lz4_LZ4JNI_LZ4_1compress_1fast_1continue
+  (JNIEnv *env, jclass cls, jbyteArray srcArray, jobject srcBuffer, jint srcOff, jint srcLen, jbyteArray destArray, jobject destBuffer, jint destOff, jint maxDestLen, jint acceleration) {
+
+  char* in;
+  char* out;
+  jint compressed;
+
+  if (srcArray != NULL) {
+    in = (char*) (*env)->GetPrimitiveArrayCritical(env, srcArray, 0);
+  } else {
+    in = (char*) (*env)->GetDirectBufferAddress(env, srcBuffer);
+  }
+
+  if (in == NULL) {
+    throw_OOM(env);
+    return 0;
+  }
+
+  if (destArray != NULL) {
+    out = (char*) (*env)->GetPrimitiveArrayCritical(env, destArray, 0);
+  } else {
+    out = (char*) (*env)->GetDirectBufferAddress(env, destBuffer);
+  }
+
+  if (out == NULL) {
+    throw_OOM(env);
+    return 0;
+  }
+
+  LZ4_stream_t lz4_state;
+  LZ4_resetStream (&lz4_state);
+  compressed = LZ4_compress_fast_continue (&lz4_state, in + srcOff, out + destOff, srcLen, maxDestLen, acceleration);
+
+  if (srcArray != NULL) {
+    (*env)->ReleasePrimitiveArrayCritical(env, srcArray, in, 0);
+  }
+  if (destArray != NULL) {
+    (*env)->ReleasePrimitiveArrayCritical(env, destArray, out, 0);
+  }
+
+  return compressed;
+}
+
+/*
+ * Class:     net_jpountz_lz4_LZ4JNI
  * Method:    LZ4_compressHC
  * Signature: ([BLjava/nio/ByteBuffer;II[BLjava/nio/ByteBuffer;III)I
  */

--- a/src/test/net/jpountz/lz4/LZ4Test.java
+++ b/src/test/net/jpountz/lz4/LZ4Test.java
@@ -24,6 +24,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.ReadOnlyBufferException;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.io.File;
 import java.io.FilenameFilter;
@@ -483,6 +484,19 @@ public class LZ4Test extends AbstractLZ4Test {
         13, 85, 5, 72, 13, 72, 13, 85, 5, 72, 13, -19, -24, -101, -35
       };
     testRoundTrip(data, 9, data.length - 9);
+  }
+
+  @Test
+  public void testNativeFastContinue() {
+    final byte[] src = "01234567890123456789".getBytes(StandardCharsets.US_ASCII);
+    final byte[] dest = new byte[LZ4JNI.LZ4_compressBound(src.length)];
+    final int compressLen = LZ4JNI.LZ4_compress_fast_continue(src, null, 0, src.length, dest, null, 0, dest.length, 1);
+    final byte[] compressed = Arrays.copyOf(dest, compressLen);
+
+    final byte[] decompressed = new byte[src.length];
+    final int decompressedLen = LZ4JNI.LZ4_decompress_fast(compressed, null, 0, decompressed, null, 0, decompressed.length);
+    assertEquals(compressLen, decompressedLen);
+    assertArrayEquals(src, decompressed);
   }
 
   private static void assertCompressedArrayEquals(String message, byte[] expected, byte[] actual) {


### PR DESCRIPTION
Expose native LZ4_compress_fast_continue API in LZ4JNI to allow using accelerate feature