### PR TITLE
Remove double byte copy in lz4 unsafe utils

### DIFF
--- a/src/java-unsafe/net/jpountz/lz4/LZ4UnsafeUtils.java
+++ b/src/java-unsafe/net/jpountz/lz4/LZ4UnsafeUtils.java
@@ -98,7 +98,6 @@ enum LZ4UnsafeUtils {
 
   static void safeIncrementalCopy(byte[] dest, int matchOff, int dOff, int matchLen) {
     for (int i = 0; i < matchLen; ++i) {
-      dest[dOff + i] = dest[matchOff + i];
       writeByte(dest, dOff + i, readByte(dest, matchOff + i));
     }
   }


### PR DESCRIPTION
Currently in LZ4UnsafeUtils#safeIncrementalCopy every byte is copied
twice. First the byte is copied using the normal byte array syntax and
then the byte is copied using unsafe. Only one of these copies is
needed. This commit deletes the non-unsafe copy.