### PR TITLE
https://github.com/lz4/lz4-java/issues/218 add option to prefer java

### DIFF
--- a/src/java/net/jpountz/lz4/LZ4Factory.java
+++ b/src/java/net/jpountz/lz4/LZ4Factory.java
@@ -56,9 +56,15 @@ public final class LZ4Factory {
     }
   }
 
+  private static final boolean PREFER_NATIVE;
   private static LZ4Factory NATIVE_INSTANCE,
                             JAVA_UNSAFE_INSTANCE,
                             JAVA_SAFE_INSTANCE;
+
+  static {
+    final String preferNativeStr = System.getProperty("net.jpountz.lz4.PREFER_NATIVE");
+    PREFER_NATIVE = preferNativeStr == null || Boolean.valueOf(preferNativeStr);
+  }
 
   /**
    * Returns a {@link LZ4Factory} instance that returns compressors and
@@ -160,7 +166,7 @@ public final class LZ4Factory {
    * @return the fastest available {@link LZ4Factory} instance
    */
   public static LZ4Factory fastestInstance() {
-    if (Native.isLoaded()
+    if (PREFER_NATIVE && Native.isLoaded()
         || Native.class.getClassLoader() == ClassLoader.getSystemClassLoader()) {
       try {
         return nativeInstance();


### PR DESCRIPTION
added a system property "net.jpountz.lz4.PREFER_NATIVE" (defaults to true when absent). By setting "net.jpountz.lz4.PREFER_NATIVE=false" we can prefer the java version in LZ4Factory.fastestInstance().